### PR TITLE
fix: fixes publish job

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -10,11 +10,3 @@ jobs:
   tests:
     name: Run Tests
     uses: ./.github/workflows/tests.yaml
-
-  # TODO: Remove once tested
-  publish-bundle:
-    name: Publish Bundle
-    needs: tests
-    uses: ./.github/workflows/publish.yaml
-    secrets:
-      CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -10,3 +10,11 @@ jobs:
   tests:
     name: Run Tests
     uses: ./.github/workflows/tests.yaml
+
+  # TODO: Remove once tested
+  publish-bundle:
+    name: Publish Bundle
+    needs: tests
+    uses: ./.github/workflows/publish.yaml
+    secrets:
+      CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -17,11 +17,3 @@ jobs:
   tests:
     name: Run Tests
     uses: ./.github/workflows/tests.yaml
-
-  # publish runs in series with tests, and only publishes if tests passes
-  publish-bundle:
-    name: Publish Bundle
-    needs: tests
-    uses: ./.github/workflows/publish.yaml
-    secrets:
-      CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -45,4 +45,4 @@ jobs:
         if: failure()
         run: |
           printenv | sed 's;=.*;;' | sort
-          awk '{print}' /home/runner/snap/charmcraft/common/cache/charmcraft/log/*.log
+          awk '{print}' /home/runner/.local/state/charmcraft/log/*.log

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,10 +1,12 @@
 name: Publish and release to latest/edge
 
 on:
-  workflow_call:
-    secrets:
-      CHARMCRAFT_CREDENTIALS:
-        required: true
+  push:
+    branches:
+      - main
+      - track/**
+    paths:
+      - "./bundle.yaml.j2"
 
 jobs:
   publish-bundle-edge:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bundle: iam
+        bundle: [iam]
     env:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
     steps:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,9 +17,13 @@ jobs:
     env:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
-        run: sudo snap install charmcraft --classic --channel=latest/edge
+        run: |
+          sudo snap install charmcraft --classic --channel=latest/edge
+          sudo apt-get update -yqq
+          sudo apt-get install -yqq python3-pip
+          sudo --preserve-env=http_proxy,https_proxy,no_proxy pip3 install tox
       - name: Pack and publish bundle
         run: |
           set -ex


### PR DESCRIPTION
Bundle publishing on push failed. This PR fixes the action:
- install tox before bundle rendering
- correct logs location in logdump
- update actions/checkout to v3
- publish the bundle only if its template has changed - for example, when we change dependencies channel. Otherwise there is no need to keep publishing the same bundle
- insufficient charmcraft access was updated by adding a new secret.