### PR TITLE
Fix workflow for publishing bundle

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,7 @@ on:
       - main
       - track/**
     paths:
-      - "./bundle.yaml.j2"
+      - "bundle.yaml.j2"
 
 jobs:
   publish-bundle-edge:

--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -71,7 +71,7 @@ relations:
   - [hydra:public-ingress, traefik-public:ingress]
   - [kratos:admin-ingress, traefik-admin:ingress]
   - [kratos:public-ingress, traefik-public:ingress]
-#  - [identity-platform-login-ui-operator:ingress, traefik-public:ingress]
+  - [identity-platform-login-ui-operator:ingress, traefik-public:ingress]
   {% if testing -%}
 # TODO: Uncomment when oauth relation interface is available
 #  - [grafana:oauth, hydra:oauth]


### PR DESCRIPTION
The job for publishing the bundle if its template has changed doesn't run because it references a path relative to the workflow file. This PR fixes it by changing it to absolute path.