### PR TITLE
Upgrade `pytest-operator` to 0.26.0

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 pytest
 jinja2
 juju
-pytest-operator==0.22.0
+pytest-operator==0.26.0
 -r requirements.txt


### PR DESCRIPTION
With the recent update of `pytest` to 7.3.0 (see [changelog](https://github.com/pytest-dev/pytest/releases/tag/7.3.0)), `pytest-operator` in v0.22 is failing in this repo's tests due to an error on setup:
```
Traceback (most recent call last):
  File "/home/runner/work/iam-bundle/iam-bundle/.tox/integration/lib/python3.10/site-packages/pytest_operator/plugin.py", line 149, in tmp_path_factory
    return pytest.TempPathFactory(
TypeError: TempPathFactory.__init__() missing 2 required positional arguments: 'retention_count' and 'retention_policy'
```
This PR aims to fix it by pinning `pytest-operator` to a more recent version.