### PR TITLE
Add end-to-end tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,14 +24,8 @@ jobs:
       - name: Run integration tests
         run: tox -e integration -- --model testing
 
-      # Print out logs and metadata to assist in troubleshooting
-      - name: Get traefik-admin juju logs
-        run: juju debug-log --replay --include traefik-admin/0
-        if: failure()
-
-      - name: Get traefik-public juju logs
-        run: juju debug-log --replay --include traefik-public/0
-        if: failure()
+      - name: Print hydra logs for debugging
+        run: kubectl logs -n testing -c hydra hydra-0
 
       - name: Get contexts
         run: kubectl config view

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,15 +18,11 @@ jobs:
           channel: 1.26-strict/stable
           juju-channel: 3.1
           bootstrap-options: '--agent-version=3.1.0'
-          # provide a pool of at least 2 IP addresses to the metallb addon
+          # provide a pool of at least 3 IP addresses to the metallb addon
           microk8s-addons: "dns hostpath-storage metallb:10.64.140.43-10.64.140.49"
 
       - name: Run integration tests
         run: tox -e integration -- --model testing
-        env:
-          KRATOS_EXTERNAL_IDP_CLIENT_ID: ${{ secrets.KRATOS_EXTERNAL_IDP_CLIENT_ID }}
-          KRATOS_EXTERNAL_IDP_TENANT_ID: ${{ secrets.KRATOS_EXTERNAL_IDP_TENANT_ID }}
-          KRATOS_EXTERNAL_IDP_CLIENT_SECRET: ${{ secrets.KRATOS_EXTERNAL_IDP_CLIENT_SECRET }}
 
       # Print out logs and metadata to assist in troubleshooting
       - name: Get traefik-admin juju logs

--- a/README.md
+++ b/README.md
@@ -23,3 +23,10 @@ To deploy the bundle, run `juju deploy ./bundle-edge.yaml --trust`.
 Integration tests can be run with `tox`.
 
 In order to launch tests against an already deployed bundle, run `tox -e integration -- --model=your-model --keep-models --no-deploy`.
+
+
+## Debugging Playwright tests
+To debug the playwright tests you need to run:
+```
+PWDEBUG=1 PYTHONPATH=. pytest
+```

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,7 @@
 pytest
 jinja2
 juju
+lightkube
+pytest-playwright
 pytest-operator==0.27.0
 -r requirements.txt

--- a/manifests/dex.yaml
+++ b/manifests/dex.yaml
@@ -1,0 +1,129 @@
+# Taken from https://github.com/dexidp/dex/blob/master/examples/k8s/dex.yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dex
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: dex
+  name: dex
+  namespace: dex
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dex
+  template:
+    metadata:
+      labels:
+        app: dex
+    spec:
+      serviceAccountName: dex # This is created below
+      containers:
+      - image: ghcr.io/dexidp/dex:v2.32.0
+        name: dex
+        command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
+
+        ports:
+        - name: http
+          containerPort: 5556
+
+        volumeMounts:
+        - name: config
+          mountPath: /etc/dex/cfg
+
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 5556
+            scheme: HTTP
+      volumes:
+      - name: config
+        configMap:
+          name: dex
+          items:
+          - key: config.yaml
+            path: config.yaml
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: dex
+  namespace: dex
+data:
+  config.yaml: |
+    issuer: {{ issuer_url | d("http://dex.dex.svc.cluster.local:5556", true) }}
+    storage:
+      type: kubernetes
+      config:
+        inCluster: true
+    web:
+      http: 0.0.0.0:5556
+    oauth2:
+      skipApprovalScreen: true
+
+    staticClients:
+    - id: {{ client_id }}
+      redirectURIs:
+      - '{{ redirect_uri | d("http://example.com/redirect", true) }}'
+      name: 'Test App'
+      secret: {{ client_secret }}
+
+    enablePasswordDB: true
+    staticPasswords:
+    - email: {{ email | d("admin@example.com", true) }}
+      # bcrypt hash of the string "password": $(echo password | htpasswd -BinC 10 admin | cut -d: -f2)
+      hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+      username: {{ username | d("admin", true) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+  namespace: dex
+spec:
+  type: LoadBalancer
+  ports:
+  - name: dex
+    port: 5556
+    protocol: TCP
+    targetPort: 5556
+  selector:
+    app: dex
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: dex
+  name: dex
+  namespace: dex
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dex
+rules:
+- apiGroups: ["dex.coreos.com"] # API group created by dex
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["create"] # To manage its own resources, dex must be able to create customresourcedefinitions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dex
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dex
+subjects:
+- kind: ServiceAccount
+  name: dex           # Service account assigned to the dex pod, created above
+  namespace: dex  # The namespace dex is running in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ target-version = ["py38"]
 [tool.isort]
 line_length = 99
 profile = "black"
+src_paths= "tests/*"
 
 # Linting tools configuration
 [tool.flake8]
@@ -42,7 +43,7 @@ copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
 
 [tool.mypy]
 pretty = true
-mypy_path = "./tests"
+mypy_path = "tests"
 follow_imports = "silent"
 warn_redundant_casts = true
 warn_unused_configs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+asyncio_mode = "auto"
 
 # Formatting tools configuration
 [tool.black]
@@ -38,3 +39,23 @@ docstring-convention = "google"
 copyright-check = "True"
 copyright-author = "Canonical Ltd."
 copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+
+[tool.mypy]
+pretty = true
+mypy_path = "./tests"
+follow_imports = "silent"
+warn_redundant_casts = true
+warn_unused_configs = true
+show_traceback = true
+show_error_codes = true
+namespace_packages = true
+explicit_package_bases = true
+check_untyped_defs = true
+allow_redefinition = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+
+# Ignore libraries that do not have type hint nor stubs
+[[tool.mypy.overrides]]
+module = ["ops.*", "pytest.*", "pytest_operator.*", "urllib3.*", "jinja2.*", "lightkube.*", "pytest_mock.*"]
+ignore_missing_imports = true

--- a/render_bundle.py
+++ b/render_bundle.py
@@ -75,7 +75,9 @@ def parse_args() -> Tuple[Path, Path, Dict[str, str]]:
     return bundle_args.template, bundle_args.output, variables
 
 
-def render_bundle(template: Path, output: Path, variables: Optional[Dict[str, str]] = None):
+def render_bundle(
+    template: Path, output: Path, variables: Optional[Dict[str, str]] = None
+) -> None:
     """The main function for rendering the bundle template."""
     if variables is None:
         variables = {}

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.

--- a/tests/integration/auth_utils.py
+++ b/tests/integration/auth_utils.py
@@ -1,0 +1,42 @@
+from base64 import b64encode
+from os.path import join
+from secrets import token_urlsafe
+from urllib.parse import urlencode
+
+import requests
+from pytest_operator.plugin import OpsTest
+
+
+def construct_authorization_url(hydra_url, client_id, client_secret):
+    params = {
+        "client_id": client_id,
+        "redirect_uri": client_secret,
+        "response_type": "code",
+        "response_mode": "query",
+        "scope": "openid profile email",
+        "state": token_urlsafe(),
+        "nonce": token_urlsafe(),
+    }
+    return join(hydra_url, "oauth2/auth?" + urlencode(params))
+
+
+def get_basic_http_auth_header(username, password):
+    token = b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+    return f"Basic {token}"
+
+
+def token_request(hydra_url, client_id, client_secret, auth_code, redirect_uri):
+    url = join(hydra_url, "oauth2/token")
+
+    body = {
+        "code": auth_code,
+        "grant_type": "authorization_code",
+        "redirect_uri": redirect_uri,
+    }
+
+    return requests.post(
+        url,
+        data=body,
+        auth=(client_id, client_secret),
+        verify=False,
+    )

--- a/tests/integration/auth_utils.py
+++ b/tests/integration/auth_utils.py
@@ -1,10 +1,13 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 from base64 import b64encode
 from os.path import join
 from secrets import token_urlsafe
 from urllib.parse import urlencode
 
 import requests
-from pytest_operator.plugin import OpsTest
 
 
 def construct_authorization_url(hydra_url, client_id, client_secret):
@@ -25,9 +28,23 @@ def get_basic_http_auth_header(username, password):
     return f"Basic {token}"
 
 
-def token_request(hydra_url, client_id, client_secret, auth_code, redirect_uri):
+def client_credentials_grant_request(hydra_url, client_id, client_secret, scope="openid profile"):
     url = join(hydra_url, "oauth2/token")
+    body = {
+        "grant_type": "client_credentials",
+        "scope": scope,
+    }
 
+    return requests.post(
+        url,
+        data=body,
+        auth=(client_id, client_secret),
+        verify=False,
+    )
+
+
+def auth_code_grant_request(hydra_url, client_id, client_secret, auth_code, redirect_uri):
+    url = join(hydra_url, "oauth2/token")
     body = {
         "code": auth_code,
         "grant_type": "authorization_code",

--- a/tests/integration/auth_utils.py
+++ b/tests/integration/auth_utils.py
@@ -2,7 +2,6 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from base64 import b64encode
 from os.path import join
 from secrets import token_urlsafe
 from urllib.parse import urlencode
@@ -10,7 +9,7 @@ from urllib.parse import urlencode
 import requests
 
 
-def construct_authorization_url(hydra_url: str, client_id: str, client_secret: str) -> str:
+def get_authorization_url(hydra_url: str, client_id: str, client_secret: str) -> str:
     params = {
         "client_id": client_id,
         "redirect_uri": client_secret,
@@ -21,11 +20,6 @@ def construct_authorization_url(hydra_url: str, client_id: str, client_secret: s
         "nonce": token_urlsafe(),
     }
     return join(hydra_url, "oauth2/auth?" + urlencode(params))
-
-
-def get_basic_http_auth_header(username: str, password: str) -> str:
-    token = b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
-    return f"Basic {token}"
 
 
 def client_credentials_grant_request(

--- a/tests/integration/auth_utils.py
+++ b/tests/integration/auth_utils.py
@@ -10,7 +10,7 @@ from urllib.parse import urlencode
 import requests
 
 
-def construct_authorization_url(hydra_url, client_id, client_secret):
+def construct_authorization_url(hydra_url: str, client_id: str, client_secret: str) -> str:
     params = {
         "client_id": client_id,
         "redirect_uri": client_secret,
@@ -23,12 +23,14 @@ def construct_authorization_url(hydra_url, client_id, client_secret):
     return join(hydra_url, "oauth2/auth?" + urlencode(params))
 
 
-def get_basic_http_auth_header(username, password):
+def get_basic_http_auth_header(username: str, password: str) -> str:
     token = b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
     return f"Basic {token}"
 
 
-def client_credentials_grant_request(hydra_url, client_id, client_secret, scope="openid profile"):
+def client_credentials_grant_request(
+    hydra_url: str, client_id: str, client_secret: str, scope: str = "openid profile"
+) -> requests.Response:
     url = join(hydra_url, "oauth2/token")
     body = {
         "grant_type": "client_credentials",
@@ -43,7 +45,9 @@ def client_credentials_grant_request(hydra_url, client_id, client_secret, scope=
     )
 
 
-def auth_code_grant_request(hydra_url, client_id, client_secret, auth_code, redirect_uri):
+def auth_code_grant_request(
+    hydra_url: str, client_id: str, client_secret: str, auth_code: str, redirect_uri: str
+) -> requests.Response:
     url = join(hydra_url, "oauth2/token")
     body = {
         "code": auth_code,
@@ -55,5 +59,18 @@ def auth_code_grant_request(hydra_url, client_id, client_secret, auth_code, redi
         url,
         data=body,
         auth=(client_id, client_secret),
+        verify=False,
+    )
+
+
+def userinfo_request(hydra_url: str, access_token: str) -> requests.Response:
+    url = join(hydra_url, "userinfo")
+
+    return requests.get(
+        url,
+        headers={
+            "Authorization": "Bearer " + access_token,
+            "Content-Type": "application/json",
+        },
         verify=False,
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import os
+from os.path import join
+from pathlib import Path
+from time import sleep
+from typing import Generator, Optional
+
+import pytest
+import requests
+from lightkube import Client, KubeConfig, codecs
+from lightkube.core.exceptions import ApiError, ObjectDeleted
+from lightkube.resources.apps_v1 import Deployment
+from lightkube.resources.core_v1 import Pod, Service
+from playwright.async_api import async_playwright
+from pytest_operator.plugin import OpsTest
+from requests.exceptions import RequestException
+
+logger = logging.getLogger(__name__)
+KUBECONFIG = os.environ.get("TESTING_KUBECONFIG", "~/.kube/config")
+DEX_MANIFESTS = Path(__file__).parent.parent.parent / "manifests" / "dex.yaml"
+
+
+@pytest.fixture(scope="session")
+def client() -> Client:
+    return Client(config=KubeConfig.from_file(KUBECONFIG), field_manager="dex-test")
+
+
+def get_dex_manifest(**context):
+    with open(DEX_MANIFESTS, "r") as file:
+        return codecs.load_all_yaml(file, context=context)
+
+
+def dex_is_ready(issuer_url=None):
+    if not issuer_url:
+        issuer_url = get_dex_service_ip(client)
+
+    resp = requests.get(join(issuer_url, ".well-known/openid-configuration"))
+    if resp.status_code != 200:
+        raise RuntimeError("Failed to deploy dex")
+
+
+def apply_dex_resources(
+    client: Client,
+    client_id: str = "client_id",
+    client_secret: str = "client_secret",
+    redirect_uri: str = "",
+    issuer_url: Optional[str] = None,
+    restart: Optional[bool] = True,
+    wait_for_ready: Optional[bool] = True,
+) -> None:
+    # Get the dex IP
+    if not issuer_url:
+        try:
+            issuer_url = get_dex_service_ip(client)
+        except ApiError:
+            logger.info("No service found for dex")
+
+    objs = get_dex_manifest(
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+        issuer_url=issuer_url,
+    )
+
+    for obj in objs:
+        client.apply(obj, force=True)
+
+    if restart:
+        logger.info("Restarting dex")
+        for pod in client.list(Pod, namespace="dex", labels={"app": "dex"}):
+            client.delete(Pod, pod.metadata.name, namespace="dex")
+
+    if wait_for_ready:
+        logger.info("Waiting for dex to be ready")
+        for pod in client.list(Pod, namespace="dex", labels={"app": "dex"}):
+            # Some pods may be deleted, if we are restarting
+            try:
+                client.wait(
+                    Pod, pod.metadata.name, for_conditions=["Ready", "Deleted"], namespace="dex"
+                )
+            except ObjectDeleted:
+                pass
+            client.wait(Deployment, "dex", namespace="dex", for_conditions=["Available"])
+
+            try:
+                dex_is_ready(issuer_url)
+            except (RuntimeError, RequestException):
+                sleep(3)
+                dex_is_ready(issuer_url)
+
+
+def get_dex_service_ip(client: Client):
+    service = client.get(Service, "dex", namespace="dex")
+    return f"http://{service.status.loadBalancer.ingress[0].ip}:5556/"
+
+
+@pytest.fixture(scope="module")
+def dex(ops_test: OpsTest, client: Client) -> Generator[str, None, None]:
+    # Use ops-lib-manifests?
+    try:
+        try:
+            client.get(Deployment, "dex", namespace="dex")
+        except ApiError:
+            logger.info("Deploying dex resources")
+            apply_dex_resources(client, restart=False)
+
+            # We need to patch the dex service to apply the metallb ip, we don't know that before
+            # the service is created
+            apply_dex_resources(client)
+
+        yield get_dex_service_ip(client)
+    finally:
+        if ops_test.keep_model:
+            return
+        logger.info("Deleting dex resources")
+        for obj in get_dex_manifest():
+            try:
+                client.delete(type(obj), obj.metadata.name, namespace=obj.metadata.namespace)
+            except ApiError:
+                pass
+
+
+@pytest.fixture()
+def dex_user_email() -> str:
+    return "admin@example.com"
+
+
+@pytest.fixture()
+def dex_user_password() -> str:
+    return "password"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -55,12 +55,12 @@ def ext_idp_service(ops_test: OpsTest, client: Client) -> Generator[str, None, N
 
 
 @pytest.fixture()
-def dex_user_email() -> str:
+def external_user_email() -> str:
     return "admin@example.com"
 
 
 @pytest.fixture()
-def dex_user_password() -> str:
+def external_user_password() -> str:
     return "password"
 
 

--- a/tests/integration/dex.py
+++ b/tests/integration/dex.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+import logging
+from os.path import join
+from pathlib import Path
+from time import sleep
+from typing import Optional
+
+import requests
+from lightkube import Client, codecs
+from lightkube.core.exceptions import ApiError, ObjectDeleted
+from lightkube.resources.apps_v1 import Deployment
+from lightkube.resources.core_v1 import Pod, Service
+from requests.exceptions import RequestException
+
+logger = logging.getLogger(__name__)
+
+
+DEX_MANIFESTS = Path(__file__).parent.parent.parent / "manifests" / "dex.yaml"
+
+
+def get_dex_manifest(**context):
+    with open(DEX_MANIFESTS, "r") as file:
+        return codecs.load_all_yaml(file, context=context)
+
+
+def dex_is_ready(client, issuer_url=None):
+    for pod in client.list(Pod, namespace="dex", labels={"app": "dex"}):
+        # Some pods may be deleted, if we are restarting
+        try:
+            client.wait(
+                Pod, pod.metadata.name, for_conditions=["Ready", "Deleted"], namespace="dex"
+            )
+        except ObjectDeleted:
+            pass
+    client.wait(Deployment, "dex", namespace="dex", for_conditions=["Available"])
+    if not issuer_url:
+        issuer_url = get_dex_service_ip(client)
+
+    resp = requests.get(join(issuer_url, ".well-known/openid-configuration"))
+    if resp.status_code != 200:
+        raise RuntimeError("Failed to deploy dex")
+
+
+def apply_dex_resources(
+    client: Client,
+    client_id: str = "client_id",
+    client_secret: str = "client_secret",
+    redirect_uri: str = "",
+    issuer_url: Optional[str] = None,
+    restart: Optional[bool] = True,
+    wait_for_ready: Optional[bool] = True,
+) -> None:
+    # Get the dex IP
+    if not issuer_url:
+        try:
+            issuer_url = get_dex_service_ip(client)
+        except ApiError:
+            logger.info("No service found for dex")
+
+    objs = get_dex_manifest(
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+        issuer_url=issuer_url,
+    )
+
+    for obj in objs:
+        client.apply(obj, force=True)
+
+    if restart:
+        logger.info("Restarting dex")
+        for pod in client.list(Pod, namespace="dex", labels={"app": "dex"}):
+            client.delete(Pod, pod.metadata.name, namespace="dex")
+
+    if wait_for_ready:
+        logger.info("Waiting for dex to be ready")
+        try:
+            dex_is_ready(client, issuer_url)
+        except (RuntimeError, RequestException):
+            sleep(3)
+            dex_is_ready(client, issuer_url)
+
+
+def get_dex_service_ip(client: Client):
+    service = client.get(Service, "dex", namespace="dex")
+    return f"http://{service.status.loadBalancer.ingress[0].ip}:5556/"

--- a/tests/integration/dex.py
+++ b/tests/integration/dex.py
@@ -93,6 +93,8 @@ def apply_dex_resources(
         try:
             dex_is_ready(client, issuer_url)
         except (RuntimeError, RequestException):
+            # It may take some time for dex to restart, so we sleep a little
+            # and try again
             sleep(3)
             dex_is_ready(client, issuer_url)
 

--- a/tests/integration/dex.py
+++ b/tests/integration/dex.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
+
 import logging
 from os.path import join
 from pathlib import Path

--- a/tests/integration/dex.py
+++ b/tests/integration/dex.py
@@ -39,7 +39,12 @@ def get_dex_manifest(
         )
 
 
-def dex_is_ready(client: Client, issuer_url: Optional[str] = None) -> None:
+def _restart_dex(client: Client) -> None:
+    for pod in client.list(Pod, namespace="dex", labels={"app": "dex"}):
+        client.delete(Pod, pod.metadata.name, namespace="dex")
+
+
+def _wait_until_dex_is_ready(client: Client, issuer_url: Optional[str] = None) -> None:
     for pod in client.list(Pod, namespace="dex", labels={"app": "dex"}):
         # Some pods may be deleted, if we are restarting
         try:
@@ -50,29 +55,30 @@ def dex_is_ready(client: Client, issuer_url: Optional[str] = None) -> None:
             pass
     client.wait(Deployment, "dex", namespace="dex", for_conditions=["Available"])
     if not issuer_url:
-        issuer_url = get_dex_service_ip(client)
+        issuer_url = get_dex_service_url(client)
 
     resp = requests.get(join(issuer_url, ".well-known/openid-configuration"))
     if resp.status_code != 200:
         raise RuntimeError("Failed to deploy dex")
 
 
-def apply_dex_resources(
+def wait_until_dex_is_ready(client: Client, issuer_url: Optional[str] = None) -> None:
+    try:
+        _wait_until_dex_is_ready(client, issuer_url)
+    except (RuntimeError, RequestException):
+        # It may take some time for dex to restart, so we sleep a little
+        # and try again
+        sleep(3)
+        _wait_until_dex_is_ready(client, issuer_url)
+
+
+def _apply_dex_manifests(
     client: Client,
     client_id: str = "client_id",
     client_secret: str = "client_secret",
     redirect_uri: str = "",
     issuer_url: Optional[str] = None,
-    restart: Optional[bool] = True,
-    wait_for_ready: Optional[bool] = True,
-) -> None:
-    # Get the dex IP
-    if not issuer_url:
-        try:
-            issuer_url = get_dex_service_ip(client)
-        except ApiError:
-            logger.info("No service found for dex")
-
+):
     objs = get_dex_manifest(
         client_id=client_id,
         client_secret=client_secret,
@@ -83,22 +89,54 @@ def apply_dex_resources(
     for obj in objs:
         client.apply(obj, force=True)
 
-    if restart:
-        logger.info("Restarting dex")
-        for pod in client.list(Pod, namespace="dex", labels={"app": "dex"}):
-            client.delete(Pod, pod.metadata.name, namespace="dex")
 
-    if wait_for_ready:
-        logger.info("Waiting for dex to be ready")
+def create_dex_resources(
+    client: Client,
+    client_id: str = "client_id",
+    client_secret: str = "client_secret",
+    redirect_uri: str = "",
+    issuer_url: Optional[str] = None,
+):
+    _apply_dex_manifests(
+        client,
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+        issuer_url=issuer_url,
+    )
+
+    logger.info("Waiting for dex to be ready")
+    wait_until_dex_is_ready(client, issuer_url)
+
+
+def apply_dex_resources(
+    client: Client,
+    client_id: str = "client_id",
+    client_secret: str = "client_secret",
+    redirect_uri: str = "",
+    issuer_url: Optional[str] = None,
+) -> None:
+    if not issuer_url:
         try:
-            dex_is_ready(client, issuer_url)
-        except (RuntimeError, RequestException):
-            # It may take some time for dex to restart, so we sleep a little
-            # and try again
-            sleep(3)
-            dex_is_ready(client, issuer_url)
+            issuer_url = get_dex_service_url(client)
+        except ApiError:
+            logger.info("No service found for dex")
+
+    _apply_dex_manifests(
+        client,
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+        issuer_url=issuer_url,
+    )
+
+    logger.info("Restarting dex")
+    _restart_dex(client)
+
+    logger.info("Waiting for dex to be ready")
+    wait_until_dex_is_ready(client, issuer_url)
 
 
-def get_dex_service_ip(client: Client) -> str:
+def get_dex_service_url(client: Client) -> str:
     service = client.get(Service, "dex", namespace="dex")
     return f"http://{service.status.loadBalancer.ingress[0].ip}:5556/"

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -270,8 +270,8 @@ async def test_create_hydra_client(ops_test: OpsTest, ext_idp_service: str) -> N
 async def test_authorization_code_flow(
     ops_test: OpsTest,
     ext_idp_service: str,
-    dex_user_email: str,
-    dex_user_password: str,
+    external_user_email: str,
+    external_user_password: str,
     page: Page,
 ) -> None:
     # This is a hack, we just need a server to be running on the redirect_uri
@@ -311,9 +311,9 @@ async def test_authorization_code_flow(
 
     # Login
     await page.get_by_placeholder("email address").click()
-    await page.get_by_placeholder("email address").fill(dex_user_email)
+    await page.get_by_placeholder("email address").fill(external_user_email)
     await page.get_by_placeholder("password").click()
-    await page.get_by_placeholder("password").fill(dex_user_password)
+    await page.get_by_placeholder("password").fill(external_user_password)
     await page.get_by_role("button", name="Login").click()
 
     await page.wait_for_url(redirect_uri + "?*")
@@ -337,7 +337,7 @@ async def test_authorization_code_flow(
     json_resp = resp.json()
 
     assert resp.status_code == 200
-    assert json_resp["email"] == dex_user_email
+    assert json_resp["email"] == external_user_email
 
 
 async def test_client_credentials_flow(

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -205,7 +205,7 @@ async def test_multiple_kratos_external_idp_integrators(
     assert "redirect-uri" in action_output.results
 
 
-async def test_kratos_scale_up(ops_test: OpsTest):
+async def test_kratos_scale_up(ops_test: OpsTest) -> None:
     """Check that kratos works after it is scaled up."""
     app_name = "kratos"
 
@@ -229,7 +229,7 @@ async def test_kratos_scale_up(ops_test: OpsTest):
     assert resp.status_code == 200
 
 
-async def test_hydra_scale_up(ops_test: OpsTest):
+async def test_hydra_scale_up(ops_test: OpsTest) -> None:
     """Check that hydra works after it is scaled up."""
     app_name = "hydra"
 
@@ -324,8 +324,15 @@ async def test_authorization_code_flow(
     )
     json_resp = resp.json()
 
-    assert "id_token" in resp.json()
-    assert "access_token" in resp.json()
+    assert "id_token" in json_resp
+    assert "access_token" in json_resp
+
+    # Try to use the access token
+    resp = userinfo_request(hydra_url, json_resp["access_token"])
+    json_resp = resp.json()
+
+    assert resp.status_code == 200
+    assert json_resp["email"] == dex_user_email
 
 
 async def test_client_credentials_flow(

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -2,6 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import collections
 import inspect
 import logging
 import os
@@ -12,21 +13,32 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 import requests
 from lightkube import Client
+from playwright.async_api import expect
 from playwright.async_api._generated import Page
 from pytest_operator.plugin import OpsTest
 
 from integration.auth_utils import (
     auth_code_grant_request,
     client_credentials_grant_request,
-    construct_authorization_url,
+    get_authorization_url,
     userinfo_request,
 )
 from integration.conftest import apply_dex_resources
 
 logger = logging.getLogger(__name__)
 
-TRAEFIK_ADMIN_APP = "traefik-admin"
-TRAEFIK_PUBLIC_APP = "traefik-public"
+APPS = collections.namedtuple(
+    "Apps",
+    ["TRAEFIK_ADMIN", "TRAEFIK_PUBLIC", "HYDRA", "KRATOS", "KRATOS_EXTERNAL_IDP_INTEGRATOR"],
+)(
+    TRAEFIK_ADMIN="traefik-admin",
+    TRAEFIK_PUBLIC="traefik-public",
+    HYDRA="hydra",
+    KRATOS="kratos",
+    KRATOS_EXTERNAL_IDP_INTEGRATOR="kratos-external-idp-integrator",
+)
+
+
 DEX_CLIENT_ID = "client_id"
 DEX_CLIENT_SECRET = "client_secret"
 
@@ -37,17 +49,8 @@ def get_this_script_dir() -> Path:
     return Path(path)
 
 
-class State:
-    """Object used to hold the (incremental) test state."""
-
-    client_id: str
-    client_secret: str
-    redirect_uri: str
-
-
-@pytest.fixture(scope="module")
-def state() -> State:
-    return State()
+def get_bundle_template() -> Path:
+    return get_this_script_dir() / ".." / ".." / "bundle.yaml.j2"
 
 
 async def get_unit_address(ops_test: OpsTest, app_name: str, unit_num: int) -> str:
@@ -71,31 +74,29 @@ async def get_reverse_proxy_app_url(
 
 @pytest.mark.skip_if_deployed
 @pytest.mark.abort_on_fail
-async def test_render_and_deploy_bundle(ops_test: OpsTest, dex: None) -> None:
+async def test_render_and_deploy_bundle(ops_test: OpsTest, ext_idp_service: None) -> None:
     """Render the bundle from template and deploy using ops_test."""
     await ops_test.model.set_config({"logging-config": "<root>=WARNING; unit=DEBUG"})
 
-    logger.info(f"Rendering bundle {get_this_script_dir() / '.. '/ '..' / 'bundle.yaml.j2'}")
+    logger.info(f"Rendering bundle {get_bundle_template()}")
 
     # set the "testing" template variable so the template renders for testing
     context = {"testing": "true", "channel": "edge"}
 
     logger.debug(f"Using context {context}")
 
-    rendered_bundle = ops_test.render_bundle(
-        get_this_script_dir() / ".." / ".." / "bundle.yaml.j2", context=context
-    )
+    rendered_bundle = ops_test.render_bundle(get_bundle_template(), context=context)
 
     logger.info(f"Rendered bundle {str(rendered_bundle)}")
 
     await ops_test.model.deploy(rendered_bundle, trust=True)
 
-    await ops_test.model.applications["kratos-external-idp-integrator"].set_config(
+    await ops_test.model.applications[APPS.KRATOS_EXTERNAL_IDP_INTEGRATOR].set_config(
         {
             "client_id": DEX_CLIENT_ID,
             "client_secret": DEX_CLIENT_SECRET,
             "provider": "generic",
-            "issuer_url": dex,
+            "issuer_url": ext_idp_service,
             "scope": "profile email",
         }
     )
@@ -111,11 +112,9 @@ async def test_render_and_deploy_bundle(ops_test: OpsTest, dex: None) -> None:
 @pytest.mark.abort_on_fail
 async def test_hydra_is_up(ops_test: OpsTest) -> None:
     """Check that hydra and its environment dependencies (e.g. the database) are responsive."""
-    app_name = "hydra"
-    admin_address = await get_app_address(ops_test, TRAEFIK_ADMIN_APP)
+    hydra_url = await get_reverse_proxy_app_url(ops_test, APPS.TRAEFIK_ADMIN, APPS.HYDRA)
 
-    health_check_url = f"https://{admin_address}/{ops_test.model.name}-{app_name}/health/ready"
-    logger.info(f"Hydra admin health check address: {health_check_url}")
+    health_check_url = join(hydra_url, "health/ready")
 
     resp = requests.get(health_check_url, verify=False)
     assert resp.status_code == 200
@@ -124,13 +123,9 @@ async def test_hydra_is_up(ops_test: OpsTest) -> None:
 @pytest.mark.abort_on_fail
 async def test_kratos_is_up(ops_test: OpsTest) -> None:
     """Check that kratos and its environment dependencies (e.g. the database) are responsive."""
-    app_name = "kratos"
-    admin_address = await get_app_address(ops_test, TRAEFIK_ADMIN_APP)
+    kratos_url = await get_reverse_proxy_app_url(ops_test, APPS.TRAEFIK_ADMIN, APPS.KRATOS)
 
-    health_check_url = (
-        f"https://{admin_address}/{ops_test.model.name}-{app_name}/admin/health/ready"
-    )
-    logger.info(f"Kratos admin health check address: {health_check_url}")
+    health_check_url = join(kratos_url, "admin/health/ready")
 
     resp = requests.get(health_check_url, verify=False)
     assert resp.status_code == 200
@@ -139,7 +134,7 @@ async def test_kratos_is_up(ops_test: OpsTest) -> None:
 @pytest.mark.abort_on_fail
 async def test_kratos_external_idp_redirect_url(ops_test: OpsTest, client: Client) -> None:
     get_redirect_uri_action = (
-        await ops_test.model.applications["kratos-external-idp-integrator"]
+        await ops_test.model.applications[APPS.KRATOS_EXTERNAL_IDP_INTEGRATOR]
         .units[0]
         .run_action("get-redirect-uri")
     )
@@ -157,7 +152,7 @@ async def test_kratos_external_idp_redirect_url(ops_test: OpsTest, client: Clien
 
 @pytest.mark.skip_if_deployed
 async def test_multiple_kratos_external_idp_integrators(
-    ops_test: OpsTest, client: Client, dex: None
+    ops_test: OpsTest, client: Client, ext_idp_service: str
 ) -> None:
     """Deploy an additional external idp integrator charm and test the action.
 
@@ -170,7 +165,7 @@ async def test_multiple_kratos_external_idp_integrators(
         "client_id": "id",
         "client_secret": "a12345",
         "provider": "generic",
-        "issuer_url": dex,
+        "issuer_url": ext_idp_service,
         "scope": "profile email",
         "provider_id": "Other",
     }
@@ -192,7 +187,7 @@ async def test_multiple_kratos_external_idp_integrators(
         timeout=360,
     )
     assert ops_test.model.applications[additional_idp_name].units[0].workload_status == "active"
-    assert ops_test.model.applications["kratos"].units[0].workload_status == "active"
+    assert ops_test.model.applications[APPS.KRATOS].units[0].workload_status == "active"
 
     # Check that the redirect_uri is returned by the action
     get_redirect_uri_action = (
@@ -207,9 +202,7 @@ async def test_multiple_kratos_external_idp_integrators(
 
 async def test_kratos_scale_up(ops_test: OpsTest) -> None:
     """Check that kratos works after it is scaled up."""
-    app_name = "kratos"
-
-    app = ops_test.model.applications[app_name]
+    app = ops_test.model.applications[APPS.KRATOS]
 
     await app.scale(3)
 
@@ -220,10 +213,8 @@ async def test_kratos_scale_up(ops_test: OpsTest) -> None:
         timeout=2000,
     )
 
-    admin_address = await get_app_address(ops_test, TRAEFIK_ADMIN_APP)
-    health_check_url = (
-        f"https://{admin_address}/{ops_test.model.name}-{app_name}/admin/health/ready"
-    )
+    kratos_url = await get_reverse_proxy_app_url(ops_test, APPS.TRAEFIK_ADMIN, APPS.KRATOS)
+    health_check_url = join(kratos_url, "admin/health/ready")
     resp = requests.get(health_check_url, verify=False)
 
     assert resp.status_code == 200
@@ -231,9 +222,7 @@ async def test_kratos_scale_up(ops_test: OpsTest) -> None:
 
 async def test_hydra_scale_up(ops_test: OpsTest) -> None:
     """Check that hydra works after it is scaled up."""
-    app_name = "hydra"
-
-    app = ops_test.model.applications[app_name]
+    app = ops_test.model.applications[APPS.HYDRA]
 
     await app.scale(3)
 
@@ -244,24 +233,19 @@ async def test_hydra_scale_up(ops_test: OpsTest) -> None:
         timeout=2000,
     )
 
-    admin_address = await get_app_address(ops_test, TRAEFIK_ADMIN_APP)
-    health_check_url = f"https://{admin_address}/{ops_test.model.name}-{app_name}/health/ready"
+    hydra_url = await get_reverse_proxy_app_url(ops_test, APPS.TRAEFIK_ADMIN, APPS.HYDRA)
+    health_check_url = join(hydra_url, "health/ready")
     resp = requests.get(health_check_url, verify=False)
 
     assert resp.status_code == 200
 
 
-async def test_create_hydra_client(ops_test: OpsTest, state: State, dex: str) -> None:
+async def test_create_hydra_client(ops_test: OpsTest, ext_idp_service: str) -> None:
     """Register a client on hydra."""
-    # This is a hack, we just need a server to be running on the redirect_uri
-    # so that when we get redirected there we don't get an connection_refused
-    # error.
-    redirect_uri = join(dex, "some", "path")
-    app = ops_test.model.applications["hydra"]
+    app = ops_test.model.applications[APPS.HYDRA]
     action = await app.units[0].run_action(
         "create-oauth-client",
         **{
-            "redirect-uris": [redirect_uri],
             "grant-types": ["authorization_code", "client_credentials"],
         },
     )
@@ -270,39 +254,49 @@ async def test_create_hydra_client(ops_test: OpsTest, state: State, dex: str) ->
 
     assert res["client-id"]
     assert res["client-secret"]
-    assert res["redirect-uris"] == redirect_uri
-
-    state.client_id = res["client-id"]
-    state.client_secret = res["client-secret"]
-    state.redirect_uri = res["redirect-uris"]
 
 
 async def test_authorization_code_flow(
     ops_test: OpsTest,
-    state: State,
-    dex: str,
+    ext_idp_service: str,
     dex_user_email: str,
     dex_user_password: str,
     page: Page,
 ) -> None:
-    hydra_url = await get_reverse_proxy_app_url(ops_test, TRAEFIK_PUBLIC_APP, "hydra")
+    # This is a hack, we just need a server to be running on the redirect_uri
+    # so that when we get redirected there we don't get a connection_refused
+    # error.
+    redirect_uri = join(ext_idp_service, "some", "path")
+    app = ops_test.model.applications[APPS.HYDRA]
+    action = await app.units[0].run_action(
+        "create-oauth-client",
+        **{
+            "redirect-uris": [redirect_uri],
+            "grant-types": ["authorization_code"],
+        },
+    )
+    res = (await action.wait()).results
+    client_id = res["client-id"]
+    client_secret = res["client-secret"]
+
+    hydra_url = await get_reverse_proxy_app_url(ops_test, APPS.TRAEFIK_PUBLIC, APPS.HYDRA)
 
     # Go to hydra authorization endpoint
-    await page.goto(construct_authorization_url(hydra_url, state.client_id, state.redirect_uri))
+    await page.goto(get_authorization_url(hydra_url, client_id, redirect_uri))
 
     expected_url = join(
         await get_reverse_proxy_app_url(
-            ops_test, TRAEFIK_PUBLIC_APP, "identity-platform-login-ui-operator"
+            ops_test, APPS.TRAEFIK_PUBLIC, "identity-platform-login-ui-operator"
         ),
         "login",
     )
-    assert page.url.startswith(expected_url + "?")
+    expect(page).to_have_url(expected_url)
 
     # Choose provider
     async with page.expect_navigation():
         await page.get_by_role("button", name="Generic").click()
 
-    assert page.url.startswith(dex)
+    expect(page).to_have_url(ext_idp_service)
 
     # Login
     await page.get_by_placeholder("email address").click()
@@ -311,16 +305,16 @@ async def test_authorization_code_flow(
     await page.get_by_placeholder("password").fill(dex_user_password)
     await page.get_by_role("button", name="Login").click()
 
-    await page.wait_for_url(state.redirect_uri + "?*")
+    await page.wait_for_url(redirect_uri + "?*")
 
-    parsed = urlparse(page.url)
-    q = parse_qs(parsed.query)
+    parsed_url = urlparse(page.url)
+    query_params = parse_qs(parsed_url.query)
 
-    assert "code" in q
+    assert "code" in query_params
 
     # Exchange code for tokens
     resp = auth_code_grant_request(
-        hydra_url, state.client_id, state.client_secret, q["code"][0], state.redirect_uri
+        hydra_url, client_id, client_secret, query_params["code"][0], redirect_uri
     )
     json_resp = resp.json()
 
@@ -337,10 +331,20 @@ async def test_authorization_code_flow(
 
 async def test_client_credentials_flow(
     ops_test: OpsTest,
-    state: State,
 ) -> None:
-    hydra_url = await get_reverse_proxy_app_url(ops_test, TRAEFIK_PUBLIC_APP, "hydra")
+    app = ops_test.model.applications[APPS.HYDRA]
+    action = await app.units[0].run_action(
+        "create-oauth-client",
+        **{
+            "grant-types": ["client_credentials"],
+        },
+    )
+    res = (await action.wait()).results
+    client_id = res["client-id"]
+    client_secret = res["client-secret"]
 
-    resp = client_credentials_grant_request(hydra_url, state.client_id, state.client_secret)
+    hydra_url = await get_reverse_proxy_app_url(ops_test, APPS.TRAEFIK_PUBLIC, APPS.HYDRA)
+
+    resp = client_credentials_grant_request(hydra_url, client_id, client_secret)
 
     assert "access_token" in resp.json()

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -204,50 +204,50 @@ async def test_multiple_kratos_external_idp_integrators(
     assert "redirect-uri" in action_output.results
 
 
-# async def test_kratos_scale_up(ops_test: OpsTest):
-#     """Check that kratos works after it is scaled up."""
-#     app_name = "kratos"
+async def test_kratos_scale_up(ops_test: OpsTest):
+    """Check that kratos works after it is scaled up."""
+    app_name = "kratos"
 
-#     app = ops_test.model.applications[app_name]
+    app = ops_test.model.applications[app_name]
 
-#     await app.scale(3)
+    await app.scale(3)
 
-#     await ops_test.model.wait_for_idle(
-#         raise_on_blocked=False,
-#         raise_on_error=False,
-#         status="active",
-#         timeout=2000,
-#     )
+    await ops_test.model.wait_for_idle(
+        raise_on_blocked=False,
+        raise_on_error=False,
+        status="active",
+        timeout=2000,
+    )
 
-#     admin_address = await get_app_address(ops_test, TRAEFIK_ADMIN_APP)
-#     health_check_url = (
-#         f"https://{admin_address}/{ops_test.model.name}-{app_name}/admin/health/ready"
-#     )
-#     resp = requests.get(health_check_url, verify=False)
+    admin_address = await get_app_address(ops_test, TRAEFIK_ADMIN_APP)
+    health_check_url = (
+        f"https://{admin_address}/{ops_test.model.name}-{app_name}/admin/health/ready"
+    )
+    resp = requests.get(health_check_url, verify=False)
 
-#     assert resp.status_code == 200
+    assert resp.status_code == 200
 
 
-# async def test_hydra_scale_up(ops_test: OpsTest):
-#     """Check that hydra works after it is scaled up."""
-#     app_name = "hydra"
+async def test_hydra_scale_up(ops_test: OpsTest):
+    """Check that hydra works after it is scaled up."""
+    app_name = "hydra"
 
-#     app = ops_test.model.applications[app_name]
+    app = ops_test.model.applications[app_name]
 
-#     await app.scale(3)
+    await app.scale(3)
 
-#     await ops_test.model.wait_for_idle(
-#         raise_on_blocked=False,
-#         raise_on_error=False,
-#         status="active",
-#         timeout=2000,
-#     )
+    await ops_test.model.wait_for_idle(
+        raise_on_blocked=False,
+        raise_on_error=False,
+        status="active",
+        timeout=2000,
+    )
 
-#     admin_address = await get_app_address(ops_test, TRAEFIK_ADMIN_APP)
-#     health_check_url = f"https://{admin_address}/{ops_test.model.name}-{app_name}/health/ready"
-#     resp = requests.get(health_check_url, verify=False)
+    admin_address = await get_app_address(ops_test, TRAEFIK_ADMIN_APP)
+    health_check_url = f"https://{admin_address}/{ops_test.model.name}-{app_name}/health/ready"
+    resp = requests.get(health_check_url, verify=False)
 
-#     assert resp.status_code == 200
+    assert resp.status_code == 200
 
 
 async def test_create_hydra_client(ops_test: OpsTest, state: State, dex: str) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -43,13 +43,10 @@ commands =
 
 [testenv:integration]
 description = Run integration tests
-passenv =
-    KRATOS_EXTERNAL_IDP_CLIENT_ID
-    KRATOS_EXTERNAL_IDP_TENANT_ID
-    KRATOS_EXTERNAL_IDP_CLIENT_SECRET
 deps =
     -r{toxinidir}/integration-requirements.txt
 commands =
+    python -m playwright install --with-deps
     pytest -v --tb native {[vars]tst_path}integration --log-cli-level=INFO -s {posargs}
 
 [testenv:render-{edge,beta,candidate,stable}]

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ description = Run integration tests
 deps =
     -r{toxinidir}/integration-requirements.txt
 commands =
-    python -m playwright install --with-deps
+    playwright install
     pytest -v --tb native {[vars]tst_path}integration --log-cli-level=INFO -s {posargs}
 
 [testenv:render-{edge,beta,candidate,stable}]


### PR DESCRIPTION
Add end to end tests using dex and playwright. 

The scaling tests are commented out because both hydra and kratos logic is bugged:
1) The units don't share the secret that the apps use
2) Scaling up hydra sets the unit's status to maintenance without changing it back.
