### PR TITLE
chore: rename bundle to identity-platform

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,12 +10,12 @@ on:
 
 jobs:
   publish-bundle-edge:
-    name: Publish iam-bundle in edge channel
+    name: Publish identity-platform bundle in edge channel
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        bundle: [iam]
+        bundle: [identity-platform]
     env:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
     steps:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ If you would like to deploy the bundle with a locally built charm, modify the fi
 ```
 
 ## Deploy a bundle
-To deploy the bundle, run `juju deploy ./bundle-edge.yaml --trust`.
+To deploy a bundle from Charmhub, run:
+
+`juju deploy identity-platform --channel edge --trust`
+
+To deploy a local bundle, run:
+
+`juju deploy ./bundle-edge.yaml --trust`
 
 ## Test the bundle
 Integration tests can be run with `tox`.

--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -34,24 +34,26 @@ applications:
     series: jammy
     scale: 1
     trust: true
-#  tls-certificates-operator:
-#    charm: tls-certificates-operator
-#    channel: stable
-#    scale: 1
-#    {%- if testing %}
-#    options:
-#      ca-common-name: demo.ca.local
-#      generate-self-signed-certificates: true
-#    {%- endif %}
+  tls-certificates-operator:
+    charm: tls-certificates-operator
+    channel: stable
+    scale: 1
+    {%- if testing %}
+    options:
+      ca-common-name: demo.ca.local
+      generate-self-signed-certificates: true
+    {%- endif %}
   traefik-admin:
     charm: traefik-k8s
     channel: edge
+    revision: 136
     series: focal
     scale: 1
     trust: true
   traefik-public:
     charm: traefik-k8s
     channel: edge
+    revision: 136
     series: focal
     scale: 1
     trust: true
@@ -69,5 +71,5 @@ relations:
   - [identity-platform-login-ui-operator:ui-endpoint-info, hydra:ui-endpoint-info]
   - [identity-platform-login-ui-operator:ui-endpoint-info, kratos:ui-endpoint-info]
   - [identity-platform-login-ui-operator:kratos-endpoint-info, kratos:kratos-endpoint-info]
-#  - [traefik-admin:certificates, tls-certificates-operator:certificates]
-#  - [traefik-public:certificates, tls-certificates-operator:certificates]
+  - [traefik-admin:certificates, tls-certificates-operator:certificates]
+  - [traefik-public:certificates, tls-certificates-operator:certificates]

--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -45,15 +45,15 @@ applications:
     {%- endif %}
   traefik-admin:
     charm: traefik-k8s
-    channel: edge
     revision: 136
+    channel: edge
     series: focal
     scale: 1
     trust: true
   traefik-public:
     charm: traefik-k8s
-    channel: edge
     revision: 136
+    channel: edge
     series: focal
     scale: 1
     trust: true

--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -1,7 +1,7 @@
 ---
 {%- set testing = testing is defined and testing.casefold() in ["1", "yes", "true"] %}
 bundle: kubernetes
-name: iam
+name: identity-platform
 website: https://github.com/canonical/iam-bundle
 issues: https://github.com/canonical/iam-bundle/issues
 applications:
@@ -55,15 +55,6 @@ applications:
     series: focal
     scale: 1
     trust: true
-  {%- if testing %}
-# TODO: Uncomment when grafana is integrated with oauth
-#  grafana-k8s:
-#    charm: grafana-k8s
-#    channel: edge
-#    series: jammy
-#    scale: 1
-#    trust: true
-  {%- endif %}
 relations:
   - [hydra:pg-database, postgresql-k8s:database]
   - [kratos:pg-database, postgresql-k8s:database]
@@ -78,9 +69,5 @@ relations:
   - [identity-platform-login-ui-operator:ui-endpoint-info, hydra:ui-endpoint-info]
   - [identity-platform-login-ui-operator:ui-endpoint-info, kratos:ui-endpoint-info]
   - [identity-platform-login-ui-operator:kratos-endpoint-info, kratos:kratos-endpoint-info]
-  {% if testing -%}
-# TODO: Uncomment when grafana is integrated with oauth
-#  - [grafana:oauth, hydra:oauth]
-  {% endif -%}
   - [traefik-admin:certificates, tls-certificates-operator:certificates]
   - [traefik-public:certificates, tls-certificates-operator:certificates]

--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -34,15 +34,15 @@ applications:
     series: jammy
     scale: 1
     trust: true
-  tls-certificates-operator:
-    charm: tls-certificates-operator
-    channel: stable
-    scale: 1
-    {%- if testing %}
-    options:
-      ca-common-name: demo.ca.local
-      generate-self-signed-certificates: true
-    {%- endif %}
+#  tls-certificates-operator:
+#    charm: tls-certificates-operator
+#    channel: stable
+#    scale: 1
+#    {%- if testing %}
+#    options:
+#      ca-common-name: demo.ca.local
+#      generate-self-signed-certificates: true
+#    {%- endif %}
   traefik-admin:
     charm: traefik-k8s
     channel: edge
@@ -69,5 +69,5 @@ relations:
   - [identity-platform-login-ui-operator:ui-endpoint-info, hydra:ui-endpoint-info]
   - [identity-platform-login-ui-operator:ui-endpoint-info, kratos:ui-endpoint-info]
   - [identity-platform-login-ui-operator:kratos-endpoint-info, kratos:kratos-endpoint-info]
-  - [traefik-admin:certificates, tls-certificates-operator:certificates]
-  - [traefik-public:certificates, tls-certificates-operator:certificates]
+#  - [traefik-admin:certificates, tls-certificates-operator:certificates]
+#  - [traefik-public:certificates, tls-certificates-operator:certificates]

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -89,7 +89,7 @@ async def test_render_and_deploy_bundle(ops_test: OpsTest, ext_idp_service: str)
 
     logger.info(f"Rendered bundle {str(rendered_bundle)}")
 
-    await ops_test.model.deploy(rendered_bundle, trust=True)
+    await ops_test.run("juju", "deploy", rendered_bundle, "--trust")
 
     await ops_test.model.applications[APPS.KRATOS_EXTERNAL_IDP_INTEGRATOR].set_config(
         {


### PR DESCRIPTION
This PR:
- renames the bundle from `iam` to `identity-platform`
- pins traefik to rev 136 due to issue with tls relation
- uses `ops_test.run` to deploy the bundle rather than `ops_test.model.deploy` due to a bug with ignoring pinned revision (https://github.com/charmed-kubernetes/pytest-operator/issues/111)