### PR TITLE
IAM-449 pin down the charms revisions

### DIFF
--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -7,12 +7,14 @@ issues: https://github.com/canonical/iam-bundle/issues
 applications:
   hydra:
     charm: hydra
+    revision: 241
     channel: {{ channel|default('edge', true) }}
     scale: 1
     series: jammy
     trust: true
   kratos:
     charm: kratos
+    revision: 352
     channel: {{ channel|default('edge', true) }}
     scale: 1
     series: jammy
@@ -24,6 +26,7 @@ applications:
     series: jammy
   identity-platform-login-ui-operator:
     charm: identity-platform-login-ui-operator
+    revision: 39
     channel: {{ channel|default('edge', true) }}
     scale: 1
     series: jammy


### PR DESCRIPTION
This pull request aims to pin down the charms' revisions. The revisions represent the latest charm versions that could be published.