### PR TITLE
bump: upgrade kratos and hydra charms

### DIFF
--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -7,14 +7,14 @@ issues: https://github.com/canonical/iam-bundle/issues
 applications:
   hydra:
     charm: hydra
-    revision: 241
+    revision: 242
     channel: {{ channel|default('edge', true) }}
     scale: 1
     series: jammy
     trust: true
   kratos:
     charm: kratos
-    revision: 352
+    revision: 353
     channel: {{ channel|default('edge', true) }}
     scale: 1
     series: jammy


### PR DESCRIPTION
This pull request aims to bump the revisions of kratos and hydra charms.

- [kratos release](https://github.com/canonical/kratos-operator/releases/tag/rev353)
- [hydra release](https://github.com/canonical/hydra-operator/releases/tag/rev242)