### PR TITLE
Fixes for track/0.1

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          sudo snap install charmcraft --classic --channel=latest/edge
+          sudo snap install charmcraft --classic
           sudo apt-get update -yqq
           sudo apt-get install -yqq python3-pip
           sudo --preserve-env=http_proxy,https_proxy,no_proxy pip3 install tox

--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -41,7 +41,7 @@ applications:
   self-signed-certificates:
     charm: self-signed-certificates
     revision: 52
-    channel: edge
+    channel: latest/edge
     scale: 1
     {%- if testing %}
     options:


### PR DESCRIPTION
Changed self-signed-certificates charm channel to latest/edge.
Changed charmcraft channel to latest/stable in the publish workflow.
