### PR TITLE
chore: bump kratos rev

### DIFF
--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -14,7 +14,7 @@ applications:
     trust: true
   kratos:
     charm: kratos
-    revision: 390
+    revision: 393
     channel: {{ channel|default('edge', true) }}
     scale: 1
     series: jammy


### PR DESCRIPTION
This PR bumps the kratos revision to 393 to include a new `kratos-info` relation in the `latest/edge` version of the identity platform bundle.

rev390 -> 393 contains the following updates:
- Fix on_schedule workflow in https://github.com/canonical/kratos-operator/pull/177
- fix(loki-rule): improve error handling in json parsing n https://github.com/canonical/kratos-operator/pull/178
- Add kratos-info interface in https://github.com/canonical/kratos-operator/pull/179