### PR TITLE
chore: unpin traefik revision

### DIFF
--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -48,15 +48,13 @@ applications:
     {%- endif %}
   traefik-admin:
     charm: traefik-k8s
-    revision: 166
-    channel: latest/edge
+    channel: latest/stable
     series: focal
     scale: 1
     trust: true
   traefik-public:
     charm: traefik-k8s
-    revision: 166
-    channel: latest/edge
+    channel: latest/stable
     series: focal
     scale: 1
     trust: true


### PR DESCRIPTION
Since traefik `latest/stable` [release](https://charmhub.io/traefik-k8s) now supports forward-auth, the revision can be unpinned.