### PR TITLE
chore: bump login ui revision

### DIFF
--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -26,7 +26,7 @@ applications:
     series: jammy
   identity-platform-login-ui-operator:
     charm: identity-platform-login-ui-operator
-    revision: 79
+    revision: 82
     channel: {{ channel|default('edge', true) }}
     scale: 1
     series: jammy


### PR DESCRIPTION
The login ui revision needs to be updated.

When deployed from rev79, it fails with:
```
unit-identity-platform-login-ui-operator-0: 12:45:27 ERROR unit.identity-platform-login-ui-operator/0.juju-log ingress:15: no relation on tracing: tracing not ready
unit-identity-platform-login-ui-operator-0: 12:45:27 INFO unit.identity-platform-login-ui-operator/0.juju-log ingress:15: Pebble plan updated with new configuration, replanning
unit-identity-platform-login-ui-operator-0: 12:45:27 ERROR unit.identity-platform-login-ui-operator/0.juju-log ingress:15: cannot perform the following tasks:
- Start service "login-ui" (cannot start service: exited quickly with code 0)
----- Logs from task 0 -----
2024-04-22T12:45:27Z INFO Most recent service output:
    A login UI for the Ory stack
    
    Usage:
       [command]
    
    Available Commands:
      completion       Generate the autocompletion script for the specified shell
      create-fga-model Creates an openfga model
      help             Help about any command
      serve            serve starts the web server
      version          Get the application's version
    
    Flags:
      -h, --help   help for this command
    
    Use " [command] --help" for more information about a command.
2024-04-22T12:45:27Z ERROR cannot start service: exited quickly with code 0
```

Changing the revision to 82 fixes the issue.