### PR TITLE
Add release-please for oauth_tools

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,36 @@
+name: release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - main
+    - "release-**"
+
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@4c5670f886fe259db4d11222f7dff41c1382304d # v3
+        with:
+          release-type: python
+          package-name: oauth_tools
+          path: oauth_tools
+          default-branch: main
+          pull-request-title-pattern: "ci: release oauth_tools ${version}"
+          token: ${{ secrets.PAT_TOKEN }}
+          include-component-in-tag: true
+          extra-files: |
+            __init__.py
+        id: release
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Workaround for https://github.com/googleapis/release-please/issues/922
+        if: ${{ steps.release.outputs.pr != '' }}
+        run: |
+          echo "Closing and reopening PR to trigger checks"
+          gh pr close ${{ fromJSON(steps.release.outputs.pr).number }} || true
+          gh pr reopen ${{ fromJSON(steps.release.outputs.pr).number }} || true
+          gh pr merge --auto --merge ${{ fromJSON(steps.release.outputs.pr).number }} || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/oauth_tools/__init__.py
+++ b/oauth_tools/__init__.py
@@ -5,3 +5,5 @@
 
 from oauth_tools.external_idp import ExternalIdpService  # noqa: F401, F403
 from oauth_tools.oauth_helpers import *  # noqa: F401, F403
+
+__version__ = "0.0.1"  # x-release-please-version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,10 +100,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "oauth_tools"
-version = "0.0.1"
 description = "A collection of tools useful for testing oauth interface"
 requires-python = ">=3.7"
-dynamic = ["dependencies"]
+dynamic = ["dependencies", "version"]
 
 [project.urls]
 "Homepage" = "https://github.com/canonical/iam-bundle"
@@ -116,6 +115,7 @@ namespaces = false
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["oauth_tools/requirements.txt"]}
+version = {attr = "oauth_tools.__version__"}
 
 [tool.setuptools.package-data]
 oauth_tools = ["*.yaml"]


### PR DESCRIPTION
Tested that the version is bumped correctly and that the ChangeLog is generated, not sure what the tag that will be created will look like (will it have the `oauth_tools` prefix?)