### PR TITLE
Remove the extra single quote character in the dex manifest

### DIFF
--- a/oauth_tools/dex.yaml
+++ b/oauth_tools/dex.yaml
@@ -125,4 +125,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: dex           # Service account assigned to the dex pod, created above
-  namespace: {{ namespace | d("dex") }}'  # The namespace dex is running i
+  namespace: {{ namespace | d("dex") }}  # The namespace dex is running i


### PR DESCRIPTION
The mismatch in the namespace, caused by the extra quote, is causing permission issues in the dex container.