### PR TITLE
ci: fix publish and release action

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -4,3 +4,4 @@ parts:
     prime:
       - README.md
       - LICENSE
+      - bundle.yaml


### PR DESCRIPTION
Since charmcraft v3, uploading the bundle fails with:
```
Upload failed with status 'rejected':
- review-error: Missing required file bundle.yaml in bundle
```
See https://github.com/canonical/iam-bundle/actions/runs/10813501429/job/29997679447#step:6:64

This PR fixes it by including the bundle file in the build directory.