### PR TITLE
ci: unpin juju agent version

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,8 +19,7 @@ jobs:
         with:
           provider: microk8s
           channel: 1.${{ matrix.version }}-strict/stable
-          juju-channel: 3.4
-          bootstrap-options: '--agent-version=3.4.0'
+          juju-channel: 3.4/stable
           # provide a pool of at least 3 IP addresses to the metallb addon
           microk8s-addons: "dns hostpath-storage metallb:10.64.140.43-10.64.140.49"
 


### PR DESCRIPTION
The integration tests started to fail: [1](https://github.com/canonical/iam-bundle/actions/runs/10869368917/job/30185623281), [2](https://github.com/canonical/iam-bundle/actions/runs/10899292374/job/30244367240)
From my local environment where the tests run successfully I infer that the pinned juju agent version is causing this.

This PR unpins the `3.4.0` agent version, so that the latest stable one is used.