### PR TITLE
chore: enable postgresql `pg_trgm` and `btree_gin` plugins

### DIFF
--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -43,6 +43,7 @@ applications:
     trust: true
     options:
       plugin_pg_trgm_enable: true
+      plugin_btree_gin_enable: true
   self-signed-certificates:
     charm: self-signed-certificates
     revision: 155

--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -41,6 +41,8 @@ applications:
     series: jammy
     scale: 1
     trust: true
+    options:
+      plugin_pg_trgm_enable: true
   self-signed-certificates:
     charm: self-signed-certificates
     revision: 155


### PR DESCRIPTION
see https://github.com/canonical/postgresql-k8s-operator/issues/701