### PR TITLE
chore: link to docs index page

### DIFF
--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -4,7 +4,7 @@ bundle: kubernetes
 name: identity-platform
 description: |
   The Canonical Identity Platform is a composable identity broker and identity provider based on open source products.
-docs: https://charmhub.io/topics/canonical-identity-platform
+docs: https://discourse.charmhub.io/t/canonical-identity-platform/11825
 website: https://github.com/canonical/iam-bundle
 issues: https://github.com/canonical/iam-bundle/issues
 applications:


### PR DESCRIPTION
Change docs link to the discourse index page to have it included on CharmHub (see https://juju.is/docs/sdk/add-docs-to-your-charmhub-page#bundle).