### PR TITLE
fix: upgrade the hydra charm version to resolve the integration test failure

### DIFF
--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -10,7 +10,7 @@ issues: https://github.com/canonical/iam-bundle/issues
 applications:
   hydra:
     charm: hydra
-    revision: 304
+    revision: 316
     channel: {{ channel|default('edge', true) }}
     scale: 1
     series: jammy


### PR DESCRIPTION
This pull request tries to upgrade the hydra since it needs to use the latest version with https://github.com/canonical/hydra-operator/pull/208