### PR TITLE
ci: add the manual trigger for release the bundle

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,7 @@
 name: Publish and release to latest/edge
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -37,8 +38,8 @@ jobs:
         run: |
           # destination_channel
           destination_channel="${{ inputs.destination_channel || steps.select-channel.outputs.name }}"
-          echo "setting output of destination_channel=$destination_channel"
-          echo "::set-output name=destination_channel::$destination_channel"
+          echo "destination_channel: $destination_channel"
+          echo "destination_channel=$destination_channel" >> $GITHUB_OUTPUT
 
       - name: Pack and publish bundle
         run: |


### PR DESCRIPTION
This pull request aims to add a manual trigger for publishing the bundle because previously it stopped you from publishing the bundle again after the PR was merged and the publish workflow failed (The publish workflow only could be triggered if the bundle.yaml file was modified).