### PR TITLE
Pin httpx

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+# TODO: remove when https://github.com/gtsystem/lightkube/issues/78 is fixed
 httpx==0.27.2
 jinja2
 juju

--- a/oauth_tools/requirements.txt
+++ b/oauth_tools/requirements.txt
@@ -2,3 +2,5 @@ pytest
 pytest-playwright
 pytest_operator
 lightkube
+# TODO: remove when https://github.com/gtsystem/lightkube/issues/78 is fixed
+httpx==0.27.2


### PR DESCRIPTION
Removed the previous fix as pinning all the packages is not the way forward as that puts too heavy of a restriction on any projects that use this library. 