### PR TITLE
chore: use tox devenv

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,8 @@ contributing to the Identity Platform bundle.
 You can use the environments created by `tox` for test development:
 
 ```shell
-tox --notest -e integration
-source .tox/integration/bin/activate
+tox devenv
+source venv/bin/activate
 ```
 
 ### Debugging Playwright tests

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ passenv =
   CHARM_BUILD_DIR
   MODEL_SETTINGS
 
-[testenv:dev]
+[testenv:py]
 description = Prepare local development tools
 deps =
     pre-commit
@@ -28,6 +28,7 @@ deps =
     types-PyYAML
     -r{toxinidir}/fmt-requirements.txt
     -r{toxinidir}/lint-requirements.txt
+    -r{toxinidir}/integration-requirements.txt
 commands =
     pre-commit install -t commit-msg
 


### PR DESCRIPTION
This is a newer feature that tox uses specifically for creating dev environments (instead of the old method of using -e).